### PR TITLE
Only remove configuration files when this plugin is uninstalled

### DIFF
--- a/scripts/on-uninstall.js
+++ b/scripts/on-uninstall.js
@@ -51,6 +51,12 @@ function attempt(fn) {
 
 module.exports = function (ctx) {
     deferral = ctx.requireCordovaModule('q').defer();
-    attempt(run)();
+    
+    // Only remove configuration files if we are removing the 
+    if((ctx.hook === 'before_plugin_rm' || ctx.hook === 'before_plugin_uninstall') &&
+       ctx.opts.plugins.includes('cordova-android-support-gradle-release')) {
+        attempt(run)();
+    } else deferral.resolve();
+    
     return deferral.promise;
 };


### PR DESCRIPTION
Currently the script runs for every plugin removal, which can have unintended side-effects

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [X] Testing has been carried out for the changes have been added

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
Stop the removal of gradle configuration files after every plugin removal unrelated to the plugin.

<!-- Describe the new behaviour added/modified and its purpose. -->
In the modified code the configuration files will only be removed when this plugin is removed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->