### PR TITLE
Update apply-changes.js

### DIFF
--- a/scripts/apply-changes.js
+++ b/scripts/apply-changes.js
@@ -61,7 +61,7 @@ function run() {
     if (customVersion) {
         var buildGradlePath = path.resolve(process.cwd(), FILE_PATHS[platformVersion]["build.gradle"]);
         var contents = fs.readFileSync(buildGradlePath).toString();
-        fs.writeFileSync(buildGradlePath, contents.replace(PACKAGE_PATTERN, "$1" + customVersion + '"'), 'utf8');
+        fs.writeFileSync(buildGradlePath, contents.replace(PACKAGE_PATTERN, "$1 $2" + customVersion + '"'), 'utf8');
         log("Wrote custom version '" + customVersion + "' to " + buildGradlePath);
 
         // plugin gradle


### PR DESCRIPTION
// compile "com.android.support:support-v4:27.+" 
// in build.gradle
Line 64:
"$1" => "$1 $2"

the former code will incorrectly replace the whole line to only "compile27.+" left.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information